### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Codecov Go Example
 
 This repository serves as an **example** on how to use [Codecov Global][4] for Go.
 
-> Note: use `-covermode=atomic` or `-covermode=count` to show how many times a statement was exected.
+> Note: use `-covermode=atomic` or `-covermode=count` to show how many times a statement was executed.
 
 # Travis CI
 


### PR DESCRIPTION
The `u` in `executed` was missing. I replaced it.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codecov/example-go/4)

<!-- Reviewable:end -->
