### PR TITLE
prevent possible splitting of package dir arg

### DIFF
--- a/go.test.sh
+++ b/go.test.sh
@@ -4,7 +4,7 @@ set -e
 echo "" > coverage.txt
 
 for d in $(go list ./... | grep -v vendor); do
-    go test -race -coverprofile=profile.out -covermode=atomic $d
+    go test -race -coverprofile=profile.out -covermode=atomic "$d"
     if [ -f profile.out ]; then
         cat profile.out >> coverage.txt
         rm profile.out


### PR DESCRIPTION
Currently the package dir given to the go test argument,
is not enclosed by double quotes, making it prone to splitting on spaces.