### PR TITLE
Using codecov/codecov-action@v1 for GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,4 +15,5 @@ jobs:
       - name: Run coverage
         run: go test -race -coverprofile=coverage.txt -covermode=atomic
       - name: Upload coverage to Codecov
-        run: bash <(curl -s https://codecov.io/bash)
+        uses: codecov/codecov-action@v1  # https://github.com/codecov/codecov-action
+


### PR DESCRIPTION
In `.github/workflows/ci.yml`, there is no bash uploader validation. I think this workflow should include a process to validate the bash uploader, but it's a little pain to write in shellscript.

However, codecov/codecov-action does validate, and I think it is better to recommend using codecov/codecov-action for GitHub Actions workflows.

ref: https://about.codecov.io/blog/validating-the-bash-script-on-ci/