### PR TITLE
Added codecov.io tests via JUnit tests conversion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
           go-version: 'stable'
       - name: Gather dependencies
         run: go mod download
-      - name: Run Coverage
+      - name: Run coverage
         run: |
           go install github.com/jstemmer/go-junit-report/v2@latest
           go test -coverprofile=coverage.out -covermode=atomic -cover -json -v ./... 2>&1 | go-junit-report -set-exit-code > tests.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,11 @@ jobs:
         run: |
           go install github.com/jstemmer/go-junit-report/v2@latest
           go test -coverprofile=coverage.out -covermode=atomic -cover -json -v ./... 2>&1 | go-junit-report -set-exit-code > tests.xml
-
       - name: Upload test results to Codecov
         uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_ORG_TOKEN }}
           files: tests.xml
-
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,24 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 'stable'
+          go-version: 'stable
+'
       - name: Gather dependencies
         run: go mod download
-      - name: Run coverage
-        run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
+        
+      - name: Run Coverage
+        run: |
+          go install github.com/jstemmer/go-junit-report/v2@latest
+          go test -coverprofile=coverage.out -covermode=atomic -cover -json -v ./... 2>&1 | go-junit-report -set-exit-code > tests.xml
+
+      - name: Upload test results to Codecov
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_ORG_TOKEN }}
+          files: tests.xml
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_ORG_TOKEN }}
+          files: coverage.out

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ jobs:
           go-version: 'stable'
       - name: Gather dependencies
         run: go mod download
-        
       - name: Run Coverage
         run: |
           go install github.com/jstemmer/go-junit-report/v2@latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: 'stable
-'
       - name: Gather dependencies
         run: go mod download
         

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 'stable
+          go-version: 'stable'
       - name: Gather dependencies
         run: go mod download
         


### PR DESCRIPTION
You guys are amazing! I have been long time advocate and implemented myself similar systems for Continuous Tests Monitoring as you guys just recently published. I already migrated all my open source Go projects (20+) to this setup and published how-to article in [go-recipes](https://github.com/nikolaydubina/go-recipes?tab=readme-ov-file#-fire-continuous-tests-monitoring-with-codecovio) (so expect more people will start using it soon! hehe).

Here I wanted to show how to do it in official example.

On choice of JUnit tests converter
- `gotestsum`, it is widely used tool, but it is too big, it does other things too. it also requires non-github path for module, which raises eyebrows a little in open source Go community.
- `go-junit-report` is developed by a guy from Google, which is nice. it is also very small and does one thing only for JUnit conversion, which is in spirit of UNIX philosophy. it also does not require any dependencies. so it is winner for me, albeit I mention other tool too in guide.

<img width="1655" alt="image" src="https://github.com/user-attachments/assets/10e31a93-64ae-4f83-a6f9-7cce3550cf51">

as for requests:
- I think Timeline trend chart would be nice per test. (or at least histogram distribution of latency by time)

Thanks again! Nice work!